### PR TITLE
Fix crash in ESP32 when Azure IoT layer triggers a SAS token refresh

### DIFF
--- a/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
+++ b/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
@@ -135,7 +135,6 @@ static int mqtt_client_init_function(mqtt_client_config_t* mqtt_client_config, m
   mqtt_config.disable_auto_reconnect = false;
   mqtt_config.event_handle = esp_mqtt_event_handler;
   mqtt_config.user_context = NULL;
-  mqtt_config.buffer_size = 1024;
   mqtt_config.cert_pem = (const char*)ca_pem;
 
   LogInfo("MQTT client target uri set to '%s'", mqtt_broker_uri);

--- a/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
+++ b/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
@@ -141,11 +141,9 @@ static int mqtt_client_init_function(mqtt_client_config_t* mqtt_client_config, m
   mqtt_config.disable_auto_reconnect = false;
   mqtt_config.event_handle = esp_mqtt_event_handler;
   mqtt_config.user_context = NULL;
-  mqtt_config.buffer_size = 1024;
   mqtt_config.cert_pem = (const char*)ca_pem;
 
   LogInfo("MQTT client target uri set to '%s'", mqtt_broker_uri);
-
   mqtt_client = esp_mqtt_client_init(&mqtt_config);
 
   if (mqtt_client == NULL)
@@ -181,7 +179,7 @@ static int mqtt_client_deinit_function(mqtt_client_handle_t mqtt_client_handle)
   esp_mqtt_client_handle_t esp_mqtt_client_handle = (esp_mqtt_client_handle_t)mqtt_client_handle;
 
   LogInfo("MQTT client being disconnected.");
-  
+
   if (esp_mqtt_client_stop(esp_mqtt_client_handle) != ESP_OK)
   {
     LogError("Failed stopping MQTT client.");

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Azure SDK for C
-version=1.0.0-beta.2
+version=1.0.0-beta.3
 author=Microsoft Corporation
 maintainer=Microsoft Corporation <aziotarduino@microsoft.com>
 sentence=Azure SDK for C library (1.3.0-beta.1) for Arduino.


### PR DESCRIPTION
The crash was caused because the handle to the MQTT client was being
incorrectly passed to esp_mqtt_client_stop (indirection bug).
Also removed setting the ESP MQTT buffer size, letting it use its
default value.

These are the stacktraces of the crashes that this change fixes:

Decoding 10 results
0x40083859: panic_abort at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/panic.c
line 402
0x4008db61: esp_system_abort at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/esp_system.c
line 129
0x40092d49: __assert_func at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/newlib/assert.c
line 85
0x4008eac1: xQueueSemaphoreTake at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/freertos/queue.c
line 1549 (discriminator 1)
0x4008ec70: xQueueTakeMutexRecursive at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/freertos/queue.c
line 731
0x40106f0a: esp_mqtt_client_stop at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/mqtt/esp-mqtt/mqtt_client.c
line 1584
0x400d4829: mqtt_client_deinit_function(void*) at
C:\code\s1\azure-sdk-for-c-arduino\examples\Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
line 187
0x400d4411: azure_iot_do_work(azure_iot_t_struct*) at
C:\code\s1\azure-sdk-for-c-arduino\examples\Azure_IoT_Central_ESP32_AzureIoTKit/AzureIoT.cpp
line 517
0x400d4f10: loop() at
C:\code\s1\azure-sdk-for-c-arduino\examples\Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
line 421
0x400df8c5: loopTask(void*) at
C:\Users\ewertons\AppData\Local\Arduino15\packages\esp32\hardware\esp32\2.0.1\cores\esp32/main.cpp
line 46

Decoding 13 results
0x40083859: panic_abort at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/panic.c
line 402
0x4008db61: esp_system_abort at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/esp_system.c
line 129
0x40092d49: __assert_func at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/newlib/assert.c
line 85
0x4009298f: multi_heap_free at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/heap/multi_heap_poisoning.c
line 253
:  (inlined by) multi_heap_free at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/heap/multi_heap_poisoning.c
line 245
0x40083eb5: heap_caps_free at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/heap/heap_caps.c
line 305
0x40092d79: free at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/newlib/heap.c
line 46
0x401111e1: esp_transport_esp_tls_destroy at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/tcp_transport/transport_ssl.c
line 458
0x4011097b: esp_transport_destroy_foundation_transport at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/tcp_transport/transport.c
line 73
:  (inlined by) esp_transport_list_destroy at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/tcp_transport/transport.c
line 132
0x40106ff6: esp_mqtt_client_destroy at
/Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/mqtt/esp-mqtt/mqtt_client.c
line 819
0x400d4847: mqtt_client_deinit_function(void*) at
C:\code\s1\azure-sdk-for-c-arduino\examples\Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
line 194
0x400d433d: azure_iot_do_work(azure_iot_t_struct*) at
C:\code\s1\azure-sdk-for-c-arduino\examples\Azure_IoT_Central_ESP32_AzureIoTKit/AzureIoT.cpp
line 420
0x400d4f10: loop() at
C:\code\s1\azure-sdk-for-c-arduino\examples\Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
line 421
0x400df8c5: loopTask(void*) at
C:\Users\ewertons\AppData\Local\Arduino15\packages\esp32\hardware\esp32\2.0.1\cores\esp32/main.cpp
line 46