### PR TITLE
Revert the user agent property name from dct to DeviceClientType

### DIFF
--- a/examples/Azure_IoT_Central_ESP32/AzureIoT.h
+++ b/examples/Azure_IoT_Central_ESP32/AzureIoT.h
@@ -499,7 +499,7 @@ typedef struct azure_iot_config_t_struct
    *              Where:
    *              <MQTT-clientid>  = <device-id> + '\0'
    *              <MQTT-username>  = <iot-hub-fqdn> + '/' + lengthof(<device-id>) + '/' + '?' + <api-version> +
-   *                                 "&dct=" + urlenc(<user-agent>) + "&model-id=" + urlenc(<pnp-model-id>) + '\0'
+   *                                 "&DeviceClientType=" + urlenc(<user-agent>) + "&model-id=" + urlenc(<pnp-model-id>) + '\0'
    *              <api-version>    = "api-version=<YYYY-MM-DD>" 
    *              <MQTT-password>) = "SharedAccessSignature sr=" + <iot-hub-fqdn> + "%2Fdevices%2F" + <device-id> +
    *                                 "&sig=" + urlenc(<sha256-string>) + "&se=" + <expiration-time> + '\0'

--- a/examples/Azure_IoT_Central_ESP32_AzureIoTKit/AzureIoT.h
+++ b/examples/Azure_IoT_Central_ESP32_AzureIoTKit/AzureIoT.h
@@ -499,7 +499,7 @@ typedef struct azure_iot_config_t_struct
    *              Where:
    *              <MQTT-clientid>  = <device-id> + '\0'
    *              <MQTT-username>  = <iot-hub-fqdn> + '/' + lengthof(<device-id>) + '/' + '?' + <api-version> +
-   *                                 "&dct=" + urlenc(<user-agent>) + "&model-id=" + urlenc(<pnp-model-id>) + '\0'
+   *                                 "&DeviceClientType=" + urlenc(<user-agent>) + "&model-id=" + urlenc(<pnp-model-id>) + '\0'
    *              <api-version>    = "api-version=<YYYY-MM-DD>" 
    *              <MQTT-password>) = "SharedAccessSignature sr=" + <iot-hub-fqdn> + "%2Fdevices%2F" + <device-id> +
    *                                 "&sig=" + urlenc(<sha256-string>) + "&se=" + <expiration-time> + '\0'

--- a/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
+++ b/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
@@ -85,7 +85,7 @@ static const char* wifi_ssid = IOT_CONFIG_WIFI_SSID;
 static const char* wifi_password = IOT_CONFIG_WIFI_PASSWORD;
 
 // TODO: remove this after updating library with Azure SDK for C version 1.3.0-beta.2 or later.
-#define AZURE_SDK_CLIENT_USER_AGENT_WORKAROUND "dct=" AZURE_SDK_CLIENT_USER_AGENT
+#define AZURE_SDK_CLIENT_USER_AGENT_WORKAROUND "DeviceClientType=" AZURE_SDK_CLIENT_USER_AGENT
 
 /* --- Function Declarations --- */
 static void sync_device_clock_with_ntp_server();


### PR DESCRIPTION
Azure IoT Hub parses the user agent information using the property
name DeviceClientType, so the client must send it with that name
otherwise the user agent string is not properly stored on Azure.
A change in the property name to "dct" can only be done after the hub is
also updated to support that name/alias.