### PR TITLE
Update the Azure SDK for C Arduino Library to version 1.0.0

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Azure SDK for C
-version=1.0.0-beta.5
+version=1.0.0
 author=Microsoft Corporation
 maintainer=Microsoft Corporation <aziotarduino@microsoft.com>
 sentence=Azure SDK for C library for Arduino.

--- a/tools/Update-Library.ps1
+++ b/tools/Update-Library.ps1
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 param(
-	$SdkVersion = $(throw "SdkVersion not provided"),
-	$NewLibraryVersion = $(throw "NewLibraryVersion not provided")
+	$SdkVersion = $(throw "Azure SDK for C Version (git tag) not provided"),
+	$NewLibraryVersion = $(throw "New Azure SDK for C Arduino Library version not provided")
 )
 
 $SrcFolder = "..\src"
@@ -11,6 +11,7 @@ $LibConfigFile = "..\library.properties"
 
 Write-Host "Cloning azure-sdk-for-c repository."
 
+git config --local core.autocrlf false
 git clone -b $SdkVersion https://github.com/Azure/azure-sdk-for-c sdkrepo
 
 Write-Host "Flattening the azure-sdk-for-c file structure and updating src/."


### PR DESCRIPTION
The library already uses azure-sdk-for-c version 1.3.2, so
we can move this Arduino library out of beta into the official
1.0.0 version.