### PR TITLE
add link to releases for more info

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Microsoft Corporation <aziotarduino@microsoft.com>
 sentence=Azure SDK for C library for Arduino.
 paragraph=This is an Arduino port of the Azure SDK for C (1.4.0-beta.1). It allows you to use your Arduino device with Azure services like Azure IoT Hub and Azure Device Provisioning Service. See README.md for more details. Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.
 category=Communication
-url=https://github.com/Azure/azure-sdk-for-c/tree/1.4.0-beta.1
+url=https://github.com/Azure/azure-sdk-for-c-arduino/releases
 architectures=*
 includes=az_core.h,az_iot.h,azure_ca.h


### PR DESCRIPTION
- Before, the more info would point to the Azure SDK for C release. It might be useful for us to point to the Arduino releases instead so that users can see the differences between the releases.