### PR TITLE
Additional Bug Fixes when Internet is not available

### DIFF
--- a/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
+++ b/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
@@ -102,7 +102,7 @@ static uint8_t az_iot_data_buffer[AZ_IOT_DATA_BUFFER_SIZE];
 
 static uint32_t properties_request_id = 0;
 static bool send_device_info = true;
-static bool inital_azure_connection = false; //Turns true when ESP32 successfully connects to Azure IoT Central for the first time
+static bool azure_initial_connect = false; //Turns true when ESP32 successfully connects to Azure IoT Central for the first time
 
 /* --- MQTT Interface Functions --- */
 /*

--- a/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
+++ b/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
@@ -406,8 +406,8 @@ void loop()
 {
   if (WiFi.status() != WL_CONNECTED)
   {
+    azure_iot_stop(&azure_iot);
     connect_to_wifi();
-    azure_iot_start(&azure_iot);
   }
   else
   {
@@ -428,7 +428,9 @@ void loop()
       case azure_iot_error:
         LogError("Azure IoT client is in error state.");
         azure_iot_stop(&azure_iot);
-        WiFi.disconnect();
+        break;
+      case azure_iot_disconnected:
+        azure_iot_start(&azure_iot);
         break;
       default:
         break;

--- a/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
+++ b/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
@@ -410,8 +410,8 @@ void loop()
 {
   if (WiFi.status() != WL_CONNECTED)
   {
+    azure_iot_stop(&azure_iot);
     connect_to_wifi();
-    azure_iot_start(&azure_iot);
   }
   else
   {
@@ -432,7 +432,9 @@ void loop()
       case azure_iot_error:
         LogError("Azure IoT client is in error state.");
         azure_iot_stop(&azure_iot);
-        WiFi.disconnect();
+        break;
+      case azure_iot_disconnected:
+        azure_iot_start(&azure_iot);
         break;
       default:
         break;


### PR DESCRIPTION
The following bugs were detected when doing further testing (both in the pre-previous bug fix code and post-previous bug fix code):
- When internet is no longer available while WiFi is still connected and then internet comes back on, ESP32 cannot connect to Azure IoT Central server
- When internet goes off during inital provisioning stage, Azure IoT Central Operation ID becomes corrupted
- When WiFi is restarted without internet connectivity, ESP32 gets stuck in an infinite Azure IoT connection loop which leads to memory exhaust