### PR TITLE
Adding pnp set telemetry call to samples.

### DIFF
--- a/examples/Azure_IoT_Central_Arduino_Nano_RP2040_Connect/Azure_IoT_Central_Arduino_Nano_RP2040_Connect.ino
+++ b/examples/Azure_IoT_Central_Arduino_Nano_RP2040_Connect/Azure_IoT_Central_Arduino_Nano_RP2040_Connect.ino
@@ -354,6 +354,7 @@ void setup()
   ArduinoBearSSL.onGetTime(get_time); // Required for server trusted root validation.
 
   azure_pnp_init();
+  azure_pnp_set_telemetry_frequency(TELEMETRY_FREQUENCY_IN_SECONDS);
 
   /* 
    * The configuration structure used by Azure IoT must remain unchanged (including data buffer) 

--- a/examples/Azure_IoT_Central_Arduino_Nano_RP2040_Connect/iot_configs.h
+++ b/examples/Azure_IoT_Central_Arduino_Nano_RP2040_Connect/iot_configs.h
@@ -18,6 +18,9 @@
 // After that, the sample automatically generates a new password and re-connects.
 #define IOT_CONFIG_MQTT_PASSWORD_LIFETIME_IN_MINUTES 60
 
+// Publish 1 message every 10 seconds.
+#define TELEMETRY_FREQUENCY_IN_SECONDS 10
+
 // Time Zone Offset
 #define IOT_CONFIG_TIME_ZONE -8
 #define IOT_CONFIG_TIME_ZONE_DAYLIGHT_SAVINGS_DIFF 1

--- a/examples/Azure_IoT_Central_Arduino_Portenta_H7/Azure_IoT_Central_Arduino_Portenta_H7.ino
+++ b/examples/Azure_IoT_Central_Arduino_Portenta_H7/Azure_IoT_Central_Arduino_Portenta_H7.ino
@@ -356,6 +356,8 @@ void setup()
   ArduinoBearSSL.onGetTime(get_time); // Required for server trusted root validation.
 
   azure_pnp_init();
+  azure_pnp_set_telemetry_frequency(TELEMETRY_FREQUENCY_IN_SECONDS);
+
   /* 
    * The configuration structure used by Azure IoT must remain unchanged (including data buffer) 
    * throughout the lifetime of the sample. This variable must also not lose context so other

--- a/examples/Azure_IoT_Central_Arduino_Portenta_H7/iot_configs.h
+++ b/examples/Azure_IoT_Central_Arduino_Portenta_H7/iot_configs.h
@@ -18,6 +18,9 @@
 // After that, the sample automatically generates a new password and re-connects.
 #define IOT_CONFIG_MQTT_PASSWORD_LIFETIME_IN_MINUTES 60
 
+// Publish 1 message every 10 seconds.
+#define TELEMETRY_FREQUENCY_IN_SECONDS 10
+
 // Time Zone Offset
 #define IOT_CONFIG_TIME_ZONE -8
 #define IOT_CONFIG_TIME_ZONE_DAYLIGHT_SAVINGS_DIFF 1

--- a/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
+++ b/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
@@ -400,6 +400,7 @@ void setup()
   sync_device_clock_with_ntp_server();
 
   azure_pnp_init();
+  azure_pnp_set_telemetry_frequency(TELEMETRY_FREQUENCY_IN_SECONDS);
 
   configure_azure_iot();
   azure_iot_start(&azure_iot);

--- a/examples/Azure_IoT_Central_ESP32/iot_configs.h
+++ b/examples/Azure_IoT_Central_ESP32/iot_configs.h
@@ -65,8 +65,8 @@
 // please update the suffix with the format '(ard;<platform>)' as an url-encoded string.
 #define AZURE_SDK_CLIENT_USER_AGENT "c%2F" AZ_SDK_VERSION_STRING "(ard%3Besp32)"
 
-// Publish 1 message every 2 seconds.
-#define TELEMETRY_FREQUENCY_IN_SECONDS 2
+// Publish 1 message every 10 seconds.
+#define TELEMETRY_FREQUENCY_IN_SECONDS 10
 
 // For how long the MQTT password (SAS token) is valid, in minutes.
 // After that, the sample automatically generates a new password and re-connects.

--- a/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
+++ b/examples/Azure_IoT_Central_ESP32_AzureIoTKit/Azure_IoT_Central_ESP32_AzureIoTKit.ino
@@ -361,6 +361,7 @@ void setup()
   sync_device_clock_with_ntp_server();
 
   azure_pnp_init();
+  azure_pnp_set_telemetry_frequency(TELEMETRY_FREQUENCY_IN_SECONDS);
 
   /*
    * The configuration structure used by Azure IoT must remain unchanged (including data buffer)

--- a/examples/Azure_IoT_Central_ESP32_AzureIoTKit/iot_configs.h
+++ b/examples/Azure_IoT_Central_ESP32_AzureIoTKit/iot_configs.h
@@ -65,8 +65,8 @@
 // please update the suffix with the format '(ard;<platform>)' as an url-encoded string.
 #define AZURE_SDK_CLIENT_USER_AGENT "c%2F" AZ_SDK_VERSION_STRING "(ard%3Besp32)"
 
-// Publish 1 message every 2 seconds.
-#define TELEMETRY_FREQUENCY_IN_SECONDS 2
+// Publish 1 message every 10 seconds.
+#define TELEMETRY_FREQUENCY_IN_SECONDS 10
 
 // For how long the MQTT password (SAS token) is valid, in minutes.
 // After that, the sample automatically generates a new password and re-connects.


### PR DESCRIPTION
Addressing missing `azure_pnp_set_telemetry_frequency` calls pointed out in: [2602](https://github.com/Azure/azure-sdk-for-c/issues/2602)