### PR TITLE
Fix missing esp_mqtt_event_handler error

### DIFF
--- a/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
+++ b/examples/Azure_IoT_Central_ESP32/Azure_IoT_Central_ESP32.ino
@@ -85,7 +85,7 @@ static void sync_device_clock_with_ntp_server();
 static void connect_to_wifi();
 
 #if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
-static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
+static void esp_mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
 #else // ESP_ARDUINO_VERSION_MAJOR
 static esp_err_t esp_mqtt_event_handler(esp_mqtt_event_handle_t event);
 #endif // ESP_ARDUINO_VERSION_MAJOR


### PR DESCRIPTION
Fix missing **_esp_mqtt_event_handler_** error i had report here: https://github.com/Azure/azure-sdk-for-c/issues/2847